### PR TITLE
Update-time-metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,14 @@ use filetime::FileTime;
 use std::fs;
 
 fn main() {
-    let metadata = fs::metadata("tests/20230224_182502.jpg").unwrap();
+    let metadata = fs::metadata("test_folder/photo@31-12-2020_19-00-00.png").unwrap();
     println!("Raw file metadata: {:?}", metadata);
+
+    filetime::set_file_mtime(
+        "test_folder/photo@31-12-2020_19-00-00.png",
+        FileTime::from_unix_time(100000, 0),
+    )
+    .unwrap();
 
     let mtime = FileTime::from_last_modification_time(&metadata);
     println!("From last mod time: {:?}", mtime);


### PR DESCRIPTION
- Implemented the function that updates the metadata using `filetime` of a file calling the `extract_datetime` and `get_timestamp` functions.
- Both of the above functions are now private